### PR TITLE
Proposal view

### DIFF
--- a/pyBuchaktion/cms_menus.py
+++ b/pyBuchaktion/cms_menus.py
@@ -14,9 +14,14 @@ class PyBuchaktionMenu(Menu):
         n4 = NavigationNode(_('Modules'), reverse('pyBuchaktion:modules'), 5004)
         nodes = [n2, n3, n4]
 
-        nodes += [NavigationNode(_("Account"), reverse('pyBuchaktion:account'), 5006),]
         #nodes += [NavigationNode(_("Logout"), reverse('pyTUID:logout'), 5020, 5006),]
         #nodes += [NavigationNode(_("Login"), reverse('pyTUID:login'), 5020),]
+
+        if hasattr(request, 'student') and request.student:
+            nodes += [NavigationNode(_("Account"), reverse('pyBuchaktion:account'), 5006),]
+            nodes += [NavigationNode(_("Propose"), reverse('pyBuchaktion:book_propose'), 5008, 5001)]
+        else:
+            nodes += [NavigationNode(_("Login"), reverse('pyBuchaktion:account'), 5006),]
 
         match = request.resolver_match
         if match.url_name in ['book', 'book_order']:

--- a/pyBuchaktion/forms.py
+++ b/pyBuchaktion/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 from django.http.request import QueryDict
+
 from .models import Student, Order, Book
 
 class BookOrderForm(forms.ModelForm):
@@ -18,11 +19,19 @@ class BookOrderForm(forms.ModelForm):
         if self.instance.student.order_set.filter(book__pk=self.instance.book_id).count() > 0:
             raise ValidationError(_("You already ordered this book"), code='already_ordered')
 
+
 class BookSearchForm(forms.Form):
     title = forms.CharField(label=_("Title"), max_length=100, required=False)
     author = forms.CharField(label=_("Author"), max_length=100, required=False)
     isbn_13 = forms.CharField(label=_("ISBN-13"), max_length=13, required=False)
     publisher = forms.CharField(label=_("Publisher"), max_length=64, required=False)
+
+
+class BookProposeForm(forms.ModelForm):
+    class Meta:
+        model = Book
+        fields = ['isbn_13', 'title', 'author', 'publisher', 'year']
+
 
 class ModuleSearchForm(forms.Form):
     name = forms.CharField(label=_("Name"), max_length=100, required=False)

--- a/pyBuchaktion/locale/de/LC_MESSAGES/django.po
+++ b/pyBuchaktion/locale/de/LC_MESSAGES/django.po
@@ -91,6 +91,11 @@ msgstr "Module"
 msgid "Account"
 msgstr "Account"
 
+#: cms_menus.py:19 templates/pyBuchaktion/book_propose.html:15
+#: templates/pyBuchaktion/books/all_list.html:28
+msgid "Propose"
+msgstr "Vorschlagen"
+
 #: cms_menus.py:43
 msgid "Order book"
 msgstr "Buch bestellen"
@@ -100,15 +105,15 @@ msgstr "Buch bestellen"
 msgid "Order #%s"
 msgstr "Bestellung #%s"
 
-#: forms.py:15
+#: forms.py:16
 msgid "This book is not available for ordering"
 msgstr "Dieses Buch kann nicht bestellt werden"
 
-#: forms.py:19
+#: forms.py:20
 msgid "You already ordered this book"
 msgstr "Du hast dieses Buch bereits bestellt"
 
-#: forms.py:22
+#: forms.py:24
 msgid "Title"
 msgstr "Titel"
 
@@ -409,6 +414,10 @@ msgstr "Empfohlen von"
 msgid "Order this book"
 msgstr "Dieses Buch bestellen"
 
+#: templates/pyBuchaktion/book_propose.html:7
+msgid "Propose a book"
+msgstr "Buchvorschlag"
+
 #: templates/pyBuchaktion/books/active_list.html:5
 #: templates/pyBuchaktion/books/all_list.html:7
 msgid "Sorry, no books matching this query were found!"
@@ -431,10 +440,6 @@ msgstr "Vollständige Liste"
 #: templates/pyBuchaktion/books/all_list.html:11
 msgid "Do you want to propose this book to us to be added for ordering?"
 msgstr "Willst du dieses Buch zur Bestellung vorschlagen?"
-
-#: templates/pyBuchaktion/books/all_list.html:28
-msgid "Propose"
-msgstr "Vorschlagen"
 
 #: templates/pyBuchaktion/books/base.html:6
 #: templates/pyBuchaktion/books/base.html:13

--- a/pyBuchaktion/templates/pyBuchaktion/book_propose.html
+++ b/pyBuchaktion/templates/pyBuchaktion/book_propose.html
@@ -1,0 +1,21 @@
+{% extends "page.html" %} {% load cms_tags view_tools i18n bootstrap_tags %}
+
+{% block content %}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h4 class="panel-title">
+                {% trans "Propose a book" %}
+            </h4>
+        </div>
+        <div class="panel-body">
+            <form method="POST">
+                {% csrf_token %}
+                {% form form %}
+                <div class="form-group">
+                    <button type="submit" class="btn btn-default">{% trans "Propose" %}</button>
+                </div>
+            </form>
+        </form>
+        </div>
+    </div>
+{% endblock content %}

--- a/pyBuchaktion/urls.py
+++ b/pyBuchaktion/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     url(r'^book/', include([
         url(r'^$', BookListView.as_view(), name = 'books'),
         url(r'^all/$', AllBookListView.as_view(), name = 'books_all'),
+        url(r'^propose/$', BookProposeView.as_view(), name = 'book_propose'),
         url(r'^(?P<pk>\d*)/', include([
             url(r'^$',BookView.as_view(), name = 'book'),
             url(r'^order/$', BookOrderView.as_view(), name = 'book_order'),

--- a/pyBuchaktion/views.py
+++ b/pyBuchaktion/views.py
@@ -180,14 +180,13 @@ class AccountView(StudentLoginRequiredMixin, NeverCacheMixin, UpdateView):
 
 
 class BookProposeView(StudentLoginRequiredMixin, CreateView):
+    model = Book
     template_name_suffix = '_propose'
-
     form_class = BookProposeForm
 
-    def get_initial(self):
-        return {'state': Book.PROPOSED, 'price': 0}
-
     def form_valid(self, form):
+        form.instance.state = Book.PROPOSED
+        result = super(BookProposeView, self).form_valid(form)
         order = Order(
             book=form.instance,
             student=self.request.student,
@@ -195,4 +194,4 @@ class BookProposeView(StudentLoginRequiredMixin, CreateView):
             order_timeframe=OrderTimeframe.current()
         )
         order.save()
-        return super(BookProposeView, self).form_valid(form)
+        return result

--- a/pyBuchaktion/views.py
+++ b/pyBuchaktion/views.py
@@ -3,7 +3,7 @@ from django.views.generic.edit import UpdateView, CreateView, BaseCreateView, De
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 
-from .forms import BookSearchForm, ModuleSearchForm, AccountEditForm, BookOrderForm
+from .forms import BookSearchForm, ModuleSearchForm, AccountEditForm, BookOrderForm, BookProposeForm
 from .models import Book, TucanModule, Order, Student, OrderTimeframe
 from .mixins import SearchFormContextMixin, StudentContextMixin, StudentLoginRequiredMixin, NeverCacheMixin
 
@@ -177,3 +177,22 @@ class AccountView(StudentLoginRequiredMixin, NeverCacheMixin, UpdateView):
 
     def get_object(self, queryset=None):
         return self.request.student
+
+
+class BookProposeView(StudentLoginRequiredMixin, CreateView):
+    template_name_suffix = '_propose'
+
+    form_class = BookProposeForm
+
+    def get_initial(self):
+        return {'state': Book.PROPOSED, 'price': 0}
+
+    def form_valid(self, form):
+        order = Order(
+            book=form.instance,
+            student=self.request.student,
+            status=Order.PENDING,
+            order_timeframe=OrderTimeframe.current()
+        )
+        order.save()
+        return super(BookProposeView, self).form_valid(form)


### PR DESCRIPTION
This is a basic concept for a proposal view, which when further developed can be used for students and for department staff members (see #16) to add new books to the system in a `PROPOSED` state. For students this will need to check and add to the order balance, department staff would not have that overhead.

Students would generally first search for a book in the main books view, upon not finding anything there, they would be provided with a link to this page (although being accessible through the menu). If tehir search query just matched a proposed book, they would be presented with the option to 'support' proposing that book, by creating an additional order for it. Additionally, an introduction needs to be written to explain what the proposal view does (create a book).

I've yet to see many other ways of implementing the workflow for proposals, if you have any different ideas, please also consider looking at #14. I've assigned the next winter semester milestone to this, as we can always ask people to write us e-mails for proposals until this feature is implemented.